### PR TITLE
bumping guacamole version and adding explicit session timeout - 24hrs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM guacamole/guacamole:1.1.0
+FROM guacamole/guacamole:1.2.0
 
 EXPOSE 8443
 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -84,6 +84,11 @@ set_optional_property() {
 
 }
 
+
+# Set session timeout to 24hrs to outlast container lifetime
+set_property "api-session-timeout" 1440
+
+
 # Print error message regarding missing required variables for MySQL authentication
 mysql_missing_vars() {
    cat <<END


### PR DESCRIPTION
* bumping guacamole 1.1.0 -> 1.2.0
* adding explicit session timeout period to 24hrs to outlast the container